### PR TITLE
FIX StepGroup now manually commits step notes

### DIFF
--- a/Common/AbstractETLPrototype.php
+++ b/Common/AbstractETLPrototype.php
@@ -425,7 +425,7 @@ abstract class AbstractETLPrototype implements ETLStepInterface
      * @inheritdoc 
      * @see iCanGenerateDebugWidgets::createDebugWidget()
      */
-    public function createDebugWidget(DebugMessage $debug_widget) : DebugMessage
+    public function createDebugWidget(DebugMessage $debug_widget)
     {
         if(empty($this->logBooks)) {
             return $debug_widget;

--- a/ETLPrototypes/StepGroup.php
+++ b/ETLPrototypes/StepGroup.php
@@ -148,6 +148,7 @@ class StepGroup implements DataFlowStepInterface
                         . ' on line ' . $el->getLine();
                     }
                     if ($this->getStopFlowOnError($step)) {
+                        NoteTaker::commitPendingNotesAll();
                         throw $e;
                     } else {
                         yield PHP_EOL . '✗ ERROR: ' . $e->getMessage();
@@ -160,6 +161,7 @@ class StepGroup implements DataFlowStepInterface
             $prevStepResult = $stepResult;
         }
         
+        NoteTaker::commitPendingNotesAll();
         return $result;
     }
     

--- a/Interfaces/NoteTakerInterface.php
+++ b/Interfaces/NoteTakerInterface.php
@@ -76,9 +76,10 @@ interface NoteTakerInterface
     /**
      * Commits all pending notes, across all `NoteTaker` instances, to their respective data sources.
      * 
-     * NOTE: Pending notes are automatically committed on `__destruct()`. You only need to use this function,
-     * if you have timing restrictions. Each commit, be it manual or automatic, clears the pending notes cache, which 
-     * means repeated commits do not cause unnecessary work.
+     * NOTE: It is recommended you manually commit pending notes, by calling this function to ensure
+     * timing. While pending notes are automatically committed on `__destruct()`, mechanisms like `TimeStampingBehavior`
+     * might not function as expected. Each commit, be it manual or automatic, clears the pending notes cache, which 
+     * means repeated commits are allowed and don't cause any issues.
      * 
      * @return void
      */


### PR DESCRIPTION
- avoids timing issues: When committing during `__destruct()` behaviors such as `TimeStampingBehavior` might not be active anymore, causing missing data errors on `dataCreate()`